### PR TITLE
Fix deadlock in state management methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
-    "lab_manager"
+    "lab_manager",
+    "circuit-breaker-lib"
 ]
 
 [workspace.package]

--- a/DEADLOCK_FIX_SUMMARY.md
+++ b/DEADLOCK_FIX_SUMMARY.md
@@ -1,0 +1,120 @@
+# Bug Fixes Summary
+
+This document summarizes the critical bug fixes applied to resolve deadlock and configuration issues.
+
+## 1. Circuit Breaker Deadlock Fix
+
+### Problem
+The `on_success` and `on_failure` methods in the circuit breaker implementation caused a deadlock:
+
+- Both methods acquired a write lock on `self.state`
+- Then called `decrement_concurrent_requests()` which attempted to acquire the same write lock
+- Since Rust's `RwLock` is not reentrant, this caused a deadlock
+
+### Location
+- File: `circuit-breaker-lib/src/lib.rs`
+- Lines: 175-224 (specifically lines 177 and 203)
+
+### Solution
+Modified both methods to perform the concurrent request decrement directly within the initial lock scope instead of calling the separate `decrement_concurrent_requests` method:
+
+**Before:**
+```rust
+async fn on_success(&self) {
+    let mut state = self.state.write().await;
+    self.decrement_concurrent_requests().await; // <- Deadlock here
+    // ... rest of logic
+}
+```
+
+**After:**
+```rust
+async fn on_success(&self) {
+    let mut state = self.state.write().await;
+    
+    // Decrement concurrent requests within the same lock scope
+    if state.concurrent_requests > 0 {
+        state.concurrent_requests -= 1;
+    }
+    
+    // ... rest of logic
+}
+```
+
+The same fix was applied to `on_failure` method.
+
+## 2. Envoy Port Derivation Fix
+
+### Problem
+The `create_default_sidecar_configs` function in the deployment script generated invalid Envoy configurations:
+
+- Used bash parameter expansion `${service: -1}` to extract the last character of service names
+- This resulted in invalid port numbers like "808e" (808 + last char 'e' from 'auth-service')
+
+### Location
+- File: `scripts/deploy-enhanced-microservices.sh`
+- Line: 349
+
+### Solution
+Replaced the invalid parameter expansion with a proper port mapping function:
+
+**Before:**
+```bash
+port_value: 808${service: -1}
+```
+
+**After:**
+```bash
+# Function to get service port based on service name
+get_service_port() {
+    case $1 in
+        "auth-service")
+            echo "8080"
+            ;;
+        "sample-service")
+            echo "8081"
+            ;;
+        "enhanced-storage-service")
+            echo "8082"
+            ;;
+        # ... other services
+        *)
+            echo "8090"  # Default port for unknown services
+            ;;
+    esac
+}
+
+# Then use: port_value: $service_port
+```
+
+## 3. Workspace Configuration Fix
+
+### Problem
+The `circuit-breaker-lib` was not included in the workspace members, causing build issues.
+
+### Location
+- File: `Cargo.toml`
+
+### Solution
+Added `circuit-breaker-lib` to the workspace members:
+
+```toml
+[workspace]
+members = [
+    "lab_manager",
+    "circuit-breaker-lib"
+]
+```
+
+## Verification
+
+1. **Circuit Breaker Fix**: The deadlock fix eliminates the potential for the same thread to acquire the same non-reentrant lock twice
+2. **Port Derivation Fix**: Bash script syntax check passes (`bash -n` successful)
+3. **Workspace Fix**: Proper workspace configuration allows for unified dependency management
+
+These fixes ensure:
+- No more deadlocks in circuit breaker state management
+- Valid numeric port numbers in Envoy configurations
+- Proper workspace-level dependency management
+
+All changes maintain backward compatibility and improve system reliability.

--- a/circuit-breaker-lib/src/lib.rs
+++ b/circuit-breaker-lib/src/lib.rs
@@ -175,7 +175,11 @@ impl CircuitBreaker {
 
     async fn on_success(&self) {
         let mut state = self.state.write().await;
-        self.decrement_concurrent_requests().await;
+        
+        // Decrement concurrent requests within the same lock scope
+        if state.concurrent_requests > 0 {
+            state.concurrent_requests -= 1;
+        }
         
         match state.state {
             CircuitState::Closed => {
@@ -201,7 +205,11 @@ impl CircuitBreaker {
 
     async fn on_failure(&self) {
         let mut state = self.state.write().await;
-        self.decrement_concurrent_requests().await;
+        
+        // Decrement concurrent requests within the same lock scope
+        if state.concurrent_requests > 0 {
+            state.concurrent_requests -= 1;
+        }
         
         state.failure_count += 1;
         state.last_failure_time = Some(Instant::now());

--- a/scripts/deploy-enhanced-microservices.sh
+++ b/scripts/deploy-enhanced-microservices.sh
@@ -295,7 +295,45 @@ wait_for_health() {
 create_default_sidecar_configs() {
     local services=("auth-service" "sample-service" "enhanced-storage-service")
     
+    # Function to get service port based on service name
+    get_service_port() {
+        case $1 in
+            "auth-service")
+                echo "8080"
+                ;;
+            "sample-service")
+                echo "8081"
+                ;;
+            "enhanced-storage-service")
+                echo "8082"
+                ;;
+            "template-service")
+                echo "8083"
+                ;;
+            "sequencing-service")
+                echo "8084"
+                ;;
+            "notification-service")
+                echo "8085"
+                ;;
+            "enhanced-rag-service")
+                echo "8086"
+                ;;
+            "event-service")
+                echo "8087"
+                ;;
+            "transaction-service")
+                echo "8088"
+                ;;
+            *)
+                echo "8090"  # Default port for unknown services
+                ;;
+        esac
+    }
+    
     for service in "${services[@]}"; do
+        local service_port=$(get_service_port "$service")
+        
         cat > "service-mesh/sidecars/${service}-envoy.yaml" << EOF
 admin:
   access_log_path: /tmp/admin_access.log
@@ -346,7 +384,7 @@ static_resources:
             address:
               socket_address:
                 address: $service
-                port_value: 808${service: -1}
+                port_value: $service_port
 EOF
     done
 }


### PR DESCRIPTION
The `on_success` and `on_failure` methods in `circuit-breaker-lib/src/lib.rs` were refactored to prevent a deadlock. Previously, these methods acquired a write lock on `self.state` and then called `decrement_concurrent_requests()`, which attempted to re-acquire the same non-reentrant `RwLock` write lock. The fix involved inlining the `concurrent_requests` decrement logic directly within the initial lock's scope, eliminating the redundant lock acquisition.

The `create_default_sidecar_configs` function in `scripts/deploy-enhanced-microservices.sh` was updated to correctly derive service ports. The previous implementation used `808${service: -1}`, which appended the last character of the service name (e.g., 'e' from 'auth-service') to '808', resulting in invalid non-numeric ports like '808e'. A new `get_service_port` function was introduced to map service names to valid numeric ports (e.g., 8080-8088), ensuring correct Envoy sidecar configurations.

Additionally, `Cargo.toml` was updated to include `circuit-breaker-lib` in the `[workspace].members` list, resolving build issues related to workspace configuration.