### PR TITLE
Fix remaining code bugs

### DIFF
--- a/enhanced_storage_service/Cargo.toml
+++ b/enhanced_storage_service/Cargo.toml
@@ -1,5 +1,3 @@
-[workspace]
-
 [package]
 name = "enhanced_storage_service"
 version = "0.1.0"

--- a/lab_manager/Cargo.toml
+++ b/lab_manager/Cargo.toml
@@ -38,7 +38,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 
 # Project-specific dependencies
-sqlx = { version = "0.8.1", default-features = false, features = ["runtime-tokio-rustls", "postgres", "uuid", "json", "chrono", "macros", "migrate"] }
+sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio-rustls", "postgres", "uuid", "json", "chrono", "macros", "migrate"] }
 axum = { version = "0.7.9", features = ["multipart"] }
 tower-http = { version = "0.5", features = ["fs", "cors"] }
 calamine = "0.22"

--- a/qaqc_service/Cargo.toml
+++ b/qaqc_service/Cargo.toml
@@ -42,8 +42,8 @@ config = "0.14"
 validator = { version = "0.18", features = ["derive"] }
 
 # Statistics and analytics
-statistical_analyzer = "0.1.0"
-linfa = { version = "0.7", features = ["ols"] }
+linfa = "0.7"
+linfa-linear = "0.7"
 ndarray = "0.15"
 
 # Metrics

--- a/spreadsheet_versioning_service/Cargo.toml
+++ b/spreadsheet_versioning_service/Cargo.toml
@@ -1,5 +1,3 @@
-[workspace]
-
 [package]
 name = "spreadsheet_versioning_service"
 version = "0.1.0"

--- a/template_service/Cargo.toml
+++ b/template_service/Cargo.toml
@@ -10,7 +10,7 @@ description = "Template management microservice for laboratory forms and data co
 axum = "0.7"
 tokio = { version = "1.0", features = ["full"] }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace", "compression", "multipart"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Several dependency and workspace configuration issues were addressed to resolve compilation errors.

*   Removed redundant `[workspace]` declarations from `enhanced_storage_service/Cargo.toml` and `spreadsheet_versioning_service/Cargo.toml`. These declarations conflicted with the main workspace setup.
*   Standardized the `sqlx` dependency in `lab_manager/Cargo.toml` to version `0.7` from `0.8.1` to align with other services and resolve `libsqlite3-sys` conflicts.
*   In `qaqc_service/Cargo.toml`:
    *   Removed the non-existent `statistical_analyzer` dependency.
    *   Corrected `linfa` dependency by replacing the invalid `ols` feature with `linfa-linear = "0.7"`, which provides OLS functionality.
*   Modified `template_service/Cargo.toml` to remove unsupported `compression` and `multipart` features from `tower-http` version `0.5`.

These changes resolved critical bugs preventing the workspace from building successfully.