### PR TITLE
Fix issues in main.rs

### DIFF
--- a/library_details_service/src/main.rs
+++ b/library_details_service/src/main.rs
@@ -1,8 +1,9 @@
 use axum::{
     routing::{get, post, put, delete},
-    Router, Server,
+    Router,
 };
 use std::sync::Arc;
+use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -105,9 +106,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!("{}:{}", config.host, config.port);
     tracing::info!("Library Details service listening on {}", addr);
     
-    Server::bind(&addr.parse()?)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = TcpListener::bind(&addr).await?;
+    axum::serve(listener, app).await?;
     
     Ok(())
 }

--- a/library_details_service/src/middleware.rs
+++ b/library_details_service/src/middleware.rs
@@ -1,7 +1,8 @@
 use axum::{
-    http::{Request, StatusCode},
+    http::StatusCode,
     middleware::Next,
     response::Response,
+    extract::Request as AxumRequest,
 };
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
@@ -14,9 +15,9 @@ pub struct Claims {
     pub roles: Vec<String>,
 }
 
-pub async fn auth_middleware<B>(
-    request: Request<B>,
-    next: Next<B>,
+pub async fn auth_middleware(
+    request: AxumRequest,
+    next: Next,
 ) -> Result<Response, StatusCode> {
     let headers = request.headers();
     // Extract the Authorization header


### PR DESCRIPTION
Compilation issues in `library_details_service/src/main.rs` and `library_details_service/src/middleware.rs` were addressed for Axum 0.7 compatibility.

*   In `main.rs`:
    *   The `axum::Server` import was removed.
    *   `tokio::net::TcpListener` was imported.
    *   The server binding and serving logic was updated from `Server::bind().serve()` to use `TcpListener::bind().await%3F` and `axum::serve(listener, app).await%3F`. This aligns with Axum 0.7's new server API.

*   In `middleware.rs`:
    *   The `auth_middleware` function signature was updated.
    *   The `Request` type for the `request` parameter was changed from `Request<B>` to `AxumRequest` (imported as `axum::extract::Request`).
    *   The `Next` type for the `next` parameter was changed from `Next<B>` to `Next`. This resolves issues with the `Next<B>` generic parameter no longer existing in Axum 0.7 middleware.
    *   An unused `Request` import was removed.

The service now compiles successfully, passing `cargo check`, `pnpm typecheck`, and `pnpm lint`.