### PR TITLE
Fix and update event_service tests

### DIFF
--- a/event_service/TEST_FIXES_SUMMARY.md
+++ b/event_service/TEST_FIXES_SUMMARY.md
@@ -1,0 +1,56 @@
+# Event Service Test Fixes Summary
+
+## Overview
+The event_service tests have been updated to work with the current codebase. The tests now compile successfully but require Redis to be running for execution.
+
+## Key Changes
+
+### 1. Test Structure Updates
+- Removed references to non-existent test modules in `tests/mod.rs`
+- Updated test structure to only include existing test files
+
+### 2. API Updates
+- Replaced references to non-existent `EventService` with `EventBus` trait
+- Updated all method calls from `publish_event` to `publish` to match the EventBus trait
+- Removed references to `unsubscribe` method which doesn't exist in EventBus trait
+
+### 3. Test Utilities Refactoring
+- Fixed imports in `test_utils.rs` to use the correct types from event_service
+- Added `cleanup_test_events` function to handle Redis cleanup
+- Updated `TestEventEnvironment` to use `EventBus` instead of `EventService`
+
+### 4. Integration Test Updates
+- Fixed ownership issues with Result values in assertions
+- Updated `EventAssertions::assert_event_published` to accept a boolean instead of Result
+- Fixed all test assertions to use `result.is_ok()` instead of mapping Results
+- Added underscore prefix to unused handler variables to suppress warnings
+
+### 5. Import Fixes
+- Removed unused imports using `cargo fix`
+- Fixed import paths to match the current crate structure
+
+## Test Status
+- **Compilation**: ✅ All tests compile successfully
+- **Execution**: ⚠️ Tests require Redis to be running (connection refused error)
+- **Test Count**: 5 integration tests + 3 library tests
+
+## Running the Tests
+
+### Library Tests (no Redis required)
+```bash
+cargo test --lib
+```
+
+### Integration Tests (requires Redis)
+```bash
+# Start Redis first
+docker run -d -p 6379:6379 redis:latest
+
+# Run integration tests
+cargo test --test '*'
+```
+
+## Future Improvements
+1. Consider adding mock implementations for testing without Redis
+2. Add more unit tests that don't require external dependencies
+3. Consider using testcontainers for automatic Redis setup in tests

--- a/event_service/tests/mod.rs
+++ b/event_service/tests/mod.rs
@@ -1,47 +1,9 @@
 pub mod test_utils;
 
 #[cfg(test)]
-pub mod unit {
-    pub mod test_event_types;
-    pub mod test_event_filters;
-    pub mod test_event_handlers;
-}
-
-#[cfg(test)]
 pub mod integration {
-    pub mod test_pub_sub_flow;
     pub mod test_cross_service_events;
-    pub mod test_event_persistence;
-}
-
-#[cfg(test)]
-pub mod performance {
-    pub mod test_event_throughput;
-    pub mod test_concurrent_subscribers;
-}
-
-#[cfg(test)]
-pub mod end_to_end {
-    pub mod test_complete_event_workflows;
 }
 
 // Re-export test utilities
-pub use test_utils::*;
-
-// Test macro for event cleanup
-#[macro_export]
-macro_rules! test_with_event_cleanup {
-    ($test_name:ident, $test_body:expr) => {
-        #[tokio::test]
-        async fn $test_name() {
-            let mut test_env = crate::test_utils::TestEventEnvironment::new().await;
-            let result = std::panic::AssertUnwindSafe($test_body(&mut test_env))
-                .catch_unwind()
-                .await;
-            test_env.cleanup().await;
-            if let Err(panic) = result {
-                std::panic::resume_unwind(panic);
-            }
-        }
-    };
-} 
+pub use test_utils::*; 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update `event_service` tests to align with the current `EventBus` API and fix compilation issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous `EventService` type was refactored into an `EventBus` trait, leading to broken test references, method calls, and an outdated test module structure. This PR updates the tests to use the new `EventBus` interface and cleans up the test suite.